### PR TITLE
fix: support nvim v0.10.4

### DIFF
--- a/bin/nvim-test
+++ b/bin/nvim-test
@@ -92,7 +92,7 @@ function get_platform() {
       echo "macos"
     fi
   else
-    if [[ $ver == 'nightly' ]] || version_cmp "$ver" 0.11; then
+    if [[ $ver == 'nightly' ]] || version_cmp "$ver" 0.10.4; then
       echo "linux-$(uname -m)"
     else
       echo "linux64"


### PR DESCRIPTION
This a follow-up to #8, this time to fix Neovim [0.10.4](https://github.com/neovim/neovim/releases/tag/v0.10.4).