### PR TITLE
feat: add CI coverage for Windows support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,75 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  stylua:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check formatting
+        run: make stylua-check
+
+  test:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: test / linux
+            os: ubuntu-latest
+            platform: unix
+          - name: test / macos
+            os: macos-latest
+            platform: unix
+          - name: test / windows
+            os: windows-latest
+            platform: windows
+            msystem: UCRT64
+            msys2_packages: >-
+              make
+              unzip
+              wget
+              mingw-w64-ucrt-x86_64-gcc
+              mingw-w64-ucrt-x86_64-lua-luarocks
+              mingw-w64-ucrt-x86_64-lua51
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - if: matrix.platform == 'unix'
+        uses: lewis6991/gh-actions-lua@master
+        with:
+          luaVersion: '5.1.5'
+
+      - if: matrix.platform == 'unix'
+        uses: leafo/gh-actions-luarocks@v4
+
+      - if: matrix.platform == 'windows'
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{ matrix.msystem }}
+          update: true
+          install: ${{ matrix.msys2_packages }}
+
+      - name: Run example suite
+        if: matrix.platform == 'unix'
+        working-directory: example
+        run: make test LOCAL=1
+
+      - name: Run example suite
+        if: matrix.platform == 'windows'
+        shell: msys2 {0}
+        working-directory: example
+        run: make test LOCAL=1 COVERAGE=false

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Adapted directly from https://github.com/neovim/neovim/tree/master/test
 
 - [Luarocks]
 - [Lua5.1]
-- MacOS or Linux
+- macOS, Linux, or MSYS2/Windows
 
 ## Usage
 
@@ -48,7 +48,7 @@ nvim-test:
 .PHONY: test
 test: nvim-test
 	nvim-test/bin/nvim-test test \
-		--lpath=$(PWD)/lua/?.lua
+		--lpath "$(CURDIR)/lua/?.lua"
 ```
 
 Add a test file `test/mytest_spec.lua` with the format:
@@ -82,7 +82,7 @@ make test
 
 ```
 nvim-test/bin/nvim-test test \
-        --lpath=.../nvim-test/example/lua/?.lua
+        --lpath .../nvim-test/example/lua/?.lua
 -------- Global test environment setup.
 -------- Running tests from test/mytest_spec.lua
 RUN       my tests run a test: 1.14 ms OK

--- a/bin/nvim-test
+++ b/bin/nvim-test
@@ -74,6 +74,29 @@ function parse_args() {
 
 parse_args "$@"
 
+function is_windows() {
+  case $(uname -s) in
+    MSYS_*|MINGW*|CYGWIN*|*_NT-*)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+function native_path() {
+  local path=$1
+  if is_windows; then
+    cygpath --mixed "$path"
+  else
+    echo "$path"
+  fi
+}
+
+NVIM_BIN=nvim
+if is_windows; then
+  NVIM_BIN=nvim.exe
+fi
+
 function version {
   echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'
 }
@@ -84,7 +107,9 @@ function version_cmp {
 
 function get_platform() {
   local ver=$1
-  if [[ $(uname -s) == Darwin ]]; then
+  if is_windows; then
+    echo "windows"
+  elif [[ $(uname -s) == Darwin ]]; then
     if [[ $ver == 'nightly' ]] || version_cmp "$ver" 0.10; then
       echo "macos-$(uname -m)"
     else
@@ -99,7 +124,6 @@ function get_platform() {
     fi
   fi
 }
-
 
 NVIM_URL=https://github.com/neovim/neovim/releases/download
 NVIM_RELEASES_URL=https://github.com/neovim/neovim-releases/releases/download
@@ -117,20 +141,35 @@ function fetch_nvim() {
   local ver=$1
   local dst=$2
   local platform; platform=$(get_platform "$ver")
-  local asset; asset="nvim-$platform"
+  local asset ext
 
+  if [[ $platform == windows ]]; then
+    asset="nvim-win64"
+    ext=zip
+  else
+    asset="nvim-$platform"
+    ext=tar.gz
+  fi
+
+  local archive; archive="$asset.$ext"
   local url
   if use_nvim_releases "$ver" "$platform"; then
-    url="$NVIM_RELEASES_URL/$ver/$asset.tar.gz"
+    url="$NVIM_RELEASES_URL/$ver/$archive"
   else
-    url="$NVIM_URL/$ver/$asset.tar.gz"
+    url="$NVIM_URL/$ver/$archive"
   fi
 
   rm -rf "$dst"
-  rm -rf "$asset.tar.gz"
+  rm -rf "$archive"
   wget "$url"
-  tar -xf "$asset.tar.gz"
-  rm -rf "$asset.tar.gz"
+
+  if [[ $ext == zip ]]; then
+    unzip -q "$archive"
+  else
+    tar -xf "$archive"
+  fi
+
+  rm -rf "$archive"
   mv "$asset" "$dst"
 }
 
@@ -142,6 +181,10 @@ function is_dir_older_than_24h() {
   local dir_mtime=$(stat -c %Y "$dir")
   local now=$(date +%s)
   [ $((now - dir_mtime)) -gt 86400 ]
+}
+
+function has_rock() {
+  $LUAROCKS show "$1" >/dev/null 2>&1
 }
 
 if [ "$NVIM_TEST_VERSION" = "nightly" ] \
@@ -168,13 +211,13 @@ fi
 
 LUAROCKS="luarocks --lua-version=5.1 --tree $DATA/luarocks"
 
-if [ ! -f "$DATA/luarocks/bin/busted" ]; then
+if ! has_rock busted; then
   echo "Installing Busted"
   $LUAROCKS install busted
 fi
 
 if [ $LUACOV_ENABLED ]; then
-  if [ ! -f "$DATA/luarocks/bin/luacov" ]; then
+  if ! has_rock luacov; then
     echo "Installing LuaCov"
     $LUAROCKS install luacov
     # Add some more reporters
@@ -189,15 +232,19 @@ if [ $INIT_ONLY ]; then
   exit
 fi
 
-eval "$($LUAROCKS path)"
+# `luarocks path` emits shell-specific commands. On MSYS2/Windows that output
+# uses `SET ...`, which is not valid in bash, so export the Lua paths directly.
+# `;;` preserves Lua's built-in search paths after the LuaRocks tree entries.
+export LUA_PATH="$($LUAROCKS path --lr-path);;"
+export LUA_CPATH="$($LUAROCKS path --lr-cpath);;"
 
-export NVIM_PRG=$NVIM_TEST/bin/nvim
+export NVIM_PRG="$NVIM_TEST/bin/$NVIM_BIN"
 export NVIM_TEST_HOME
 
-exec "$NVIM_RUNNER"/bin/nvim -ll \
-  "$NVIM_TEST_HOME/lua/nvim-test/busted/runner.lua" \
-  --helper="$NVIM_TEST_HOME/lua/nvim-test/preload.lua" \
-  --lpath="$NVIM_TEST_HOME/lua/?.lua" \
+# `-ll` is handled by nvim itself, so the runner path must be normalized here.
+exec "$NVIM_RUNNER/bin/$NVIM_BIN" -ll \
+  "$(native_path "$NVIM_TEST_HOME/lua/nvim-test/busted/runner.lua")" \
+  --helper "$NVIM_TEST_HOME/lua/nvim-test/preload.lua" \
+  --lpath "$NVIM_TEST_HOME/lua/?.lua" \
   --output nvim-test.busted.output_handler \
   "${ARGS[@]}"
-

--- a/example/Makefile
+++ b/example/Makefile
@@ -1,5 +1,7 @@
 
 LOCAL :=
+COVERAGE ?= true
+COVERAGE_FLAG := $(if $(filter true,$(COVERAGE)),--coverage)
 
 .DEFAULT_GOAL := test
 
@@ -16,6 +18,5 @@ nvim-test:
 .PHONY: test
 test: $(NVIM_TEST_HOME)
 	$(NVIM_TEST_HOME)/bin/nvim-test test \
-		--lpath=$(PWD)/lua/?.lua \
-		--verbose \
-		--coverage
+		--lpath "$(CURDIR)/lua/?.lua" \
+		--verbose $(COVERAGE_FLAG)

--- a/lua/nvim-test/busted/runner.lua
+++ b/lua/nvim-test/busted/runner.lua
@@ -1,1 +1,28 @@
+if package.config:sub(1, 1) == '\\' then
+  -- MSYS shells can leave `--lpath` patterns as `/d/.../?.lua` when invoking
+  -- native nvim.exe, so normalize just those arguments before Busted parses `arg`.
+  local function normalize_lua_path(path)
+    local drive, tail = path:match('^/([A-Za-z])/(.*)$')
+    if not drive then
+      return path
+    end
+
+    return string.format('%s:/%s', drive:upper(), tail)
+  end
+
+  local expect_lpath
+  for i, value in ipairs(arg) do
+    if expect_lpath then
+      arg[i] = normalize_lua_path(value)
+      expect_lpath = nil
+    elseif value == '--lpath' or value == '-m' then
+      expect_lpath = true
+    elseif value:match('^--lpath=') then
+      arg[i] = '--lpath=' .. normalize_lua_path(value:sub(9))
+    elseif value:match('^-m.+') then
+      arg[i] = '-m' .. normalize_lua_path(value:sub(3))
+    end
+  end
+end
+
 require('busted.runner')({ standalone = false })

--- a/lua/nvim-test/helpers.lua
+++ b/lua/nvim-test/helpers.lua
@@ -13,6 +13,19 @@ M.sleep = uv.sleep
 M.eq = assert.are.same
 M.neq = assert.are_not.same
 
+local function normalize_windows_path(path)
+  if not path or package.config:sub(1, 1) ~= '\\' then
+    return path
+  end
+
+  local drive, tail = path:match('^/([A-Za-z])/(.*)$')
+  if not drive then
+    return path
+  end
+
+  return string.format('%s:/%s', drive:upper(), tail)
+end
+
 local function epicfail(state, arguments, _)
   --- @diagnostic disable-next-line
   state.failure_message = arguments[1]
@@ -313,11 +326,14 @@ local exec_lua = M.exec_lua
 function M.clear(init_lua_path)
   check_close()
 
+  -- These env-backed paths are consumed after the shell wrapper returns, so
+  -- normalize any MSYS-style values at the point of use.
+  local nvim_test_home = normalize_windows_path(os.getenv('NVIM_TEST_HOME'))
   local nvim_cmd = {
-    os.getenv('NVIM_PRG') or 'nvim',
+    normalize_windows_path(os.getenv('NVIM_PRG')) or 'nvim',
     '--clean',
     '-u',
-    init_lua_path or 'NONE',
+    normalize_windows_path(init_lua_path) or 'NONE',
     '-i',
     'NONE',
     '--cmd',
@@ -351,15 +367,15 @@ function M.clear(init_lua_path)
   --- @type integer
   local channel = M.api.nvim_get_api_info()[1]
 
-  exec_lua(function(chan)
-    vim.opt.rtp:append(vim.env.NVIM_TEST_HOME)
+  exec_lua(function(chan, nvim_test_home)
+    vim.opt.rtp:append(nvim_test_home)
 
     local orig_print = _G.print
     function _G.print(...)
       vim.rpcnotify(chan, 'nvim_print_event', ...)
       return orig_print(...)
     end
-  end, channel)
+  end, channel, nvim_test_home)
 
   --- @type table?
   local enable_cov = package.loaded['luacov.runner']


### PR DESCRIPTION
## Summary
- add a GitHub Actions CI workflow for formatting plus example tests on Linux, macOS, and MSYS2/Windows
- keep the Windows support change in `bin/nvim-test` focused on platform detection, archive extraction, `.exe` paths, and rock detection
- document MSYS2/Windows as a supported platform in the README

## Testing
- `make stylua-check`
- `make test LOCAL=1` (from `example/`)
