### PR TITLE
fix(preload): fix runner error when coxpcall installed

### DIFF
--- a/lua/nvim-test/preload.lua
+++ b/lua/nvim-test/preload.lua
@@ -1,8 +1,8 @@
 local orig_pcall = pcall
 
 if package.loaded['jit'] then
-  local coxpcall = orig_pcall(require, 'coxpcall')
-  if coxpcall then
+  local ok, coxpcall = orig_pcall(require, 'coxpcall')
+  if ok then
     pcall = coxpcall.pcall
   end
 end


### PR DESCRIPTION
The test helper tries to swap the global `pcall` for the coroutine-safe one from the `coxpcall` rock, but it crashes outright if the copxcall is installed.

Before with coxpcall installed:

    $ make test
    deps/nvim-test/bin/nvim-test test \
    	--lpath=~/sources/gitsigns.nvim/lua/?.lua \
    	--verbose \
    	--filter="infers linked worktrees"
    runner.lua: failed running the specified helper (~/sources/gitsigns.nvim/deps/nvim-test/lua/nvim-test/preload.lua), error: ...s/gitsigns.nvim/deps/nvim-test/lua/nvim-test/preload.lua:6: attempt to index local 'coxpcall' (a boolean value)
    E5113: Lua chunk: nil
    make: *** [Makefile:43: test] Error 1

Note that `pcall` returns a status flag *followed by* the call's own results, and only the first value was bound, causing the above error.

https://www.lua.org/pil/8.4.html

After:

    $ make test
    -------- Global test environment teardown.
    ======== 1 test from 13 test files ran. (404.67 ms total)
    PASSED   1 test.